### PR TITLE
Use multiprocessing.Lock instead of threading.Lock

### DIFF
--- a/Containers/base-py/ai4e_api_tools/task_management/api_task.py
+++ b/Containers/base-py/ai4e_api_tools/task_management/api_task.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 import json
 import os
-import threading
+import multiprocessing
 from typing import Any, Dict
 import uuid
 
@@ -17,7 +17,7 @@ LOCAL_BLOB_TEST_DIRECTORY = os.getenv('LOCAL_BLOB_TEST_DIRECTORY', '.')
 class TaskManager:
 
     # use a lock whenever we access task_status.json
-    task_status_json_lock = threading.Lock()
+    task_status_json_lock = multiprocessing.Lock()
 
     def __init__(self):
         self.status_dict = {}


### PR DESCRIPTION
A `multiprocessing.Lock` works everywhere a `threading.Lock` does, and also is also valid in multiprocessing settings. In the CameraTraps repo, we sometimes indeed use the TaskManager class in a multiprocess setting with gunicorn having multiple worker processes.